### PR TITLE
#23 - fix position + fix removing parent publisher container

### DIFF
--- a/src/js/OTHelpers.coffee
+++ b/src/js/OTHelpers.coffee
@@ -19,15 +19,11 @@ getPosition = (divName) ->
   while(pubDiv = pubDiv.offsetParent)
     curleft += pubDiv.offsetLeft
     curtop += pubDiv.offsetTop
-  marginTop = parseInt(computedStyle.marginTop) || 0
-  marginBottom = parseInt(computedStyle.marginBottom) || 0
-  marginLeft = parseInt(computedStyle.marginLeft) || 0
-  marginRight = parseInt(computedStyle.marginRight) || 0
   return {
-    top:curtop + marginTop
-    left:curleft + marginLeft
-    width:width - (marginLeft + marginRight)
-    height:height - (marginTop + marginBottom)
+    top:curtop
+    left:curleft
+    width:width
+    height:height
   }
 
 replaceWithVideoStream = (divName, streamId, properties) ->

--- a/src/js/OTSession.coffee
+++ b/src/js/OTSession.coffee
@@ -110,7 +110,7 @@ class TBSession
     console.log("JS: Unpublish")
     element = document.getElementById( @publisher.domId )
     if(element)
-      element.parentNode.removeChild(element)
+      @resetElement(element)
       TBUpdateObjects()
     return Cordova.exec(TBSuccess, TBError, OTPlugin, "unpublish", [] )
   unsubscribe: (subscriber) ->
@@ -136,8 +136,8 @@ class TBSession
     objects = document.getElementsByClassName('OT_root')
     while( objects.length > 0 )
       e = objects[0]
-      if e and e.parentNode and e.parentNode.removeChild
-        e.parentNode.removeChild(e)
+      if e
+        @resetElement(e)
       objects = document.getElementsByClassName('OT_root')
   resetElement: (element) =>
     attributes = ['style', 'data-streamid', 'class']

--- a/www/opentok.js
+++ b/www/opentok.js
@@ -163,7 +163,7 @@ var OTPublisherError, OTReplacePublisher, TBError, TBGenerateDomHelper, TBGetScr
 streamElements = {};
 
 getPosition = function(divName) {
-  var computedStyle, curleft, curtop, height, marginBottom, marginLeft, marginRight, marginTop, pubDiv, width;
+  var computedStyle, curleft, curtop, height, pubDiv, width;
   pubDiv = document.getElementById(divName);
   if (!pubDiv) {
     return {};
@@ -177,15 +177,11 @@ getPosition = function(divName) {
     curleft += pubDiv.offsetLeft;
     curtop += pubDiv.offsetTop;
   }
-  marginTop = parseInt(computedStyle.marginTop) || 0;
-  marginBottom = parseInt(computedStyle.marginBottom) || 0;
-  marginLeft = parseInt(computedStyle.marginLeft) || 0;
-  marginRight = parseInt(computedStyle.marginRight) || 0;
   return {
-    top: curtop + marginTop,
-    left: curleft + marginLeft,
-    width: width - (marginLeft + marginRight),
-    height: height - (marginTop + marginBottom)
+    top: curtop,
+    left: curleft,
+    width: width,
+    height: height
   };
 };
 
@@ -628,7 +624,7 @@ TBSession = (function() {
     console.log("JS: Unpublish");
     element = document.getElementById(this.publisher.domId);
     if (element) {
-      element.parentNode.removeChild(element);
+      this.resetElement(element);
       TBUpdateObjects();
     }
     return Cordova.exec(TBSuccess, TBError, OTPlugin, "unpublish", []);
@@ -678,8 +674,8 @@ TBSession = (function() {
     _results = [];
     while (objects.length > 0) {
       e = objects[0];
-      if (e && e.parentNode && e.parentNode.removeChild) {
-        e.parentNode.removeChild(e);
+      if (e) {
+        this.resetElement(e);
       }
       _results.push(objects = document.getElementsByClassName('OT_root'));
     }


### PR DESCRIPTION
`getPosition()` added margins from the container and itself, therefore the video was not displayed correctly. 

`unpublish()` also removed the parent container from where it was appended, therefore this DOM element is missing in the view when inserting a publisher back again.