### PR TITLE
Fix crash when archiving session

### DIFF
--- a/src/ios/OpenTokPlugin.m
+++ b/src/ios/OpenTokPlugin.m
@@ -630,7 +630,7 @@
 - (void)session:(OTSession*)session archiveStartedWithId:(nonnull NSString *)archiveId name:(NSString *_Nullable)name{
     NSMutableDictionary* data = [[NSMutableDictionary alloc] init];
     [data setObject: archiveId forKey: @"id"];
-    [data setObject: name forKey: @"name"];
+    [data setObject: (name == nil) ? @"" : name forKey: @"name"];
     [self triggerJSEvent: @"sessionEvents" withType: @"archiveStarted" withData: data];
 }
 - (void)session:(OTSession*)session archiveStoppedWithId:(nonnull NSString *)archiveId{


### PR DESCRIPTION
when the session is archived, the name is null sometimes, which causes a crash, so this adds a check for that.

<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure you followed the Contribution Guidelines. Which can be found here:
https://github.com/opentok/cordova-plugin-opentok/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message

### Solves issue(s)
<!--- Mention the GitHub issues here -->