### PR TITLE
Fix OpenTok.h not found in mac case-sensitive file system

### DIFF
--- a/src/ios/OpenTokPlugin.h
+++ b/src/ios/OpenTokPlugin.h
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 #import <Cordova/CDVPlugin.h>
 #import <UIKit/UIKit.h>
-#import <Opentok/Opentok.h>
+#import <OpenTok/OpenTok.h>
 
 @interface OpenTokPlugin : CDVPlugin <OTSessionDelegate, OTPublisherDelegate, OTSubscriberKitDelegate>
 


### PR DESCRIPTION
### Solves

In Mac with case-sensitive file system, Opentok/Opentok.h cannot be found.