### PR TITLE
#112 Added check to ensure we don't unsubscribe when disconnected

### DIFF
--- a/src/android/OpenTokAndroidPlugin.java
+++ b/src/android/OpenTokAndroidPlugin.java
@@ -61,6 +61,7 @@ public class OpenTokAndroidPlugin extends CordovaPlugin
     public static final String TAG = "OTPlugin";
     public boolean sessionConnected;
     public boolean publishCalled; // we need this because creating publisher before sessionConnected = crash
+    public boolean isDisconnecting;
     public RunnablePublisher myPublisher;
     public HashMap<String, CallbackContext> myEventListeners;
     public HashMap<String, Connection> connectionCollection;
@@ -366,7 +367,7 @@ public class OpenTokAndroidPlugin extends CordovaPlugin
         public void removeStreamView() {
             ViewGroup parent = (ViewGroup) webView.getView().getParent();
             parent.removeView(this.mView);
-            if(mSubscriber != null) {
+            if(mSubscriber != null && !isDisconnecting) {
                 try {
                     mSession.unsubscribe(mSubscriber);
                     mSubscriber.destroy();
@@ -578,9 +579,11 @@ public class OpenTokAndroidPlugin extends CordovaPlugin
             Log.i(TAG, "adding new event - " + args.getString(0));
             myEventListeners.put(args.getString(0), callbackContext);
         } else if (action.equals("connect")) {
+            isDisconnecting = false;
             Log.i(TAG, "connect command called");
             mSession.connect(args.getString(0));
         } else if (action.equals("disconnect")) {
+            isDisconnecting = true;
             mSession.disconnect();
         } else if (action.equals("publish")) {
             if (sessionConnected) {

--- a/src/android/OpenTokAndroidPlugin.java
+++ b/src/android/OpenTokAndroidPlugin.java
@@ -615,6 +615,7 @@ public class OpenTokAndroidPlugin extends CordovaPlugin
             final RunnableSubscriber runsub = subscriberCollection.get( args.getString(0) );
             if (runsub != null) {
                 runsub.removeStreamView();
+                subscriberCollection.remove(args.getString(0));
                 callbackContext.success();
                 return true;
             }


### PR DESCRIPTION
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure you followed the Contribution Guidelines. Which can be found here:
https://github.com/opentok/cordova-plugin-opentok/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message

### Solves issue(s)
#112 

### Explanation
When disconnecting from session, there are still events being emitted, and depending on which one comes first, it will try to unsubscribe a subscriber while the Session doesn't know the subscriber. And that causes crashes. 

I added a simple check to prevent that, it is a different boolean then the `sessionConnected` boolean because that one gets sets within those events, so it wouldnt have much influences. This way it does not break any of the current code. (also added a `subscriberCollection.remove` because otherwise it will try to remove subscriber that doesnt exist anymore)