### PR TITLE
Fix issue 118

### DIFF
--- a/scripts/downloadNpmDependencies.js
+++ b/scripts/downloadNpmDependencies.js
@@ -4,6 +4,7 @@
   var fs = require('fs');
   var path = require('path');
   var spawnSync = require('child_process').spawnSync;
+  var q = require('q');
   var INSTALLFLAGNAME = '.installed';
 
   // entry
@@ -14,7 +15,7 @@
   // install the node dependencies for this project
   function install (context) {
     // set properties
-    var q = context.requireCordovaModule('q');
+    // var q = context.requireCordovaModule('q');
     var async = new q.defer(); // eslint-disable-line
     var installFlagLocation = path.join(context.opts.projectRoot, 'plugins', context.opts.plugin.id, INSTALLFLAGNAME);
     var dependencies = require(path.join(context.opts.projectRoot, 'plugins', context.opts.plugin.id, 'package.json')).dependencies;

--- a/scripts/downloadiOSSDK.js
+++ b/scripts/downloadiOSSDK.js
@@ -4,7 +4,7 @@ module.exports = function (context) {
     var IosSDKVersion = "OpenTok-iOS-2.15.3";
     var downloadFile = require('./downloadFile.js'),
         exec = require('./exec/exec.js'),
-        Q = context.requireCordovaModule('q'),
+        Q = require('q'),
         deferral = new Q.defer();
     console.log('Downloading OpenTok iOS SDK');
     downloadFile('https://s3.amazonaws.com/artifact.tokbox.com/rel/ios-sdk/' + IosSDKVersion + '.tar.bz2',

--- a/src/js/OT.coffee
+++ b/src/js/OT.coffee
@@ -1,7 +1,7 @@
 # TB Object:
 #   Methods: 
 #     TB.checkSystemRequirements() :number
-#     TB.initPublisher( apiKey:String [, replaceElementId:String] [, properties:Object] ):Publisher
+#     TB.initPublisher( apiKey:String [, replaceElementId:String] [, properties:Object] [, completionHandler:Function] ):Publisher
 #     TB.initSession( apiKey, sessionId ):Session 
 #     TB.log( message )
 #     TB.off( type:String, listener:Function )
@@ -13,8 +13,8 @@
 window.OT =
   checkSystemRequirements: ->
     return 1
-  initPublisher: (one, two) ->
-    return new TBPublisher( one, two )
+  initPublisher: (one, two, three) ->
+    return new TBPublisher( one, two, three )
   initSession: (apiKey, sessionId ) ->
     if( not sessionId? ) then @showError( "OT.initSession takes 2 parameters, your API Key and Session ID" )
     return new TBSession(apiKey, sessionId)

--- a/src/js/OTPublisher.coffee
+++ b/src/js/OTPublisher.coffee
@@ -15,7 +15,7 @@
 #     setStyle( style, value ) : publisher - not yet implemented
 #
 class TBPublisher
-  constructor: (one, two) ->
+  constructor: (one, two, three) ->
     @sanitizeInputs(one, two)
     pdebug "creating publisher", {}
     position = getPosition(@pubElement)
@@ -61,7 +61,15 @@ class TBPublisher
     position = getPosition(@pubElement)
     TBUpdateObjects()
     OT.getHelper().eventing(@)
-    Cordova.exec(TBSuccess, TBError, OTPlugin, "initPublisher", [name, position.top, position.left, width, height, zIndex, publishAudio, publishVideo, cameraName, ratios.widthRatio, ratios.heightRatio, audioFallbackEnabled, audioBitrate, audioSource, videoSource, frameRate, resolution] )
+    onSuccess = (result) ->
+      if (three?)
+        three(result);
+      return TBSuccess(result);
+    onError = (result) ->
+      if (three?)
+        three(result);
+      return TBError(result);
+    Cordova.exec(onSuccess, onError, OTPlugin, "initPublisher", [name, position.top, position.left, width, height, zIndex, publishAudio, publishVideo, cameraName, ratios.widthRatio, ratios.heightRatio, audioFallbackEnabled, audioBitrate, audioSource, videoSource, frameRate, resolution] )
     Cordova.exec(@eventReceived, TBSuccess, OTPlugin, "addEvent", ["publisherEvents"] )
   setSession: (session) =>
     @session = session

--- a/www/opentok.js
+++ b/www/opentok.js
@@ -2,8 +2,8 @@ window.OT = {
   checkSystemRequirements: function() {
     return 1;
   },
-  initPublisher: function(one, two) {
-    return new TBPublisher(one, two);
+  initPublisher: function(one, two, three) {
+    return new TBPublisher(one, two, three);
   },
   initSession: function(apiKey, sessionId) {
     if (sessionId == null) {
@@ -321,13 +321,13 @@ var TBPublisher,
   __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
 TBPublisher = (function() {
-  function TBPublisher(one, two) {
+  function TBPublisher(one, two, three) {
     this.removePublisherElement = __bind(this.removePublisherElement, this);
     this.streamDestroyed = __bind(this.streamDestroyed, this);
     this.streamCreated = __bind(this.streamCreated, this);
     this.eventReceived = __bind(this.eventReceived, this);
     this.setSession = __bind(this.setSession, this);
-    var audioBitrate, audioFallbackEnabled, audioSource, cameraName, frameRate, height, insertMode, name, position, publishAudio, publishVideo, ratios, resolution, videoSource, width, zIndex, _ref, _ref1, _ref10, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9;
+    var audioBitrate, audioFallbackEnabled, audioSource, cameraName, frameRate, height, insertMode, name, onError, onSuccess, position, publishAudio, publishVideo, ratios, resolution, videoSource, width, zIndex, _ref, _ref1, _ref10, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9;
     this.sanitizeInputs(one, two);
     pdebug("creating publisher", {});
     position = getPosition(this.pubElement);
@@ -384,7 +384,19 @@ TBPublisher = (function() {
     position = getPosition(this.pubElement);
     TBUpdateObjects();
     OT.getHelper().eventing(this);
-    Cordova.exec(TBSuccess, TBError, OTPlugin, "initPublisher", [name, position.top, position.left, width, height, zIndex, publishAudio, publishVideo, cameraName, ratios.widthRatio, ratios.heightRatio, audioFallbackEnabled, audioBitrate, audioSource, videoSource, frameRate, resolution]);
+    onSuccess = function(result) {
+      if ((three != null)) {
+        three(result);
+      }
+      return TBSuccess(result);
+    };
+    onError = function(result) {
+      if ((three != null)) {
+        three(result);
+      }
+      return TBError(result);
+    };
+    Cordova.exec(onSuccess, onError, OTPlugin, "initPublisher", [name, position.top, position.left, width, height, zIndex, publishAudio, publishVideo, cameraName, ratios.widthRatio, ratios.heightRatio, audioFallbackEnabled, audioBitrate, audioSource, videoSource, frameRate, resolution]);
     Cordova.exec(this.eventReceived, TBSuccess, OTPlugin, "addEvent", ["publisherEvents"]);
   }
 


### PR DESCRIPTION
This PR adds a completion handler for **OT.initPublisher** method

### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message

### Solves issue(s)

#118 

Hope this makes sense; We needed this callback to know exactly the moment **initPublisher** returns so we can publish to session right after that.