### PR TITLE
using standard require to import q

### DIFF
--- a/scripts/downloadiOSSDK.js
+++ b/scripts/downloadiOSSDK.js
@@ -4,7 +4,7 @@ module.exports = function (context) {
     var IosSDKVersion = "OpenTok-iOS-2.15.3";
     var downloadFile = require('./downloadFile.js'),
         exec = require('./exec/exec.js'),
-        Q = context.requireCordovaModule('q'),
+        Q = require('q'),
         deferral = new Q.defer();
     console.log('Downloading OpenTok iOS SDK');
     downloadFile('https://s3.amazonaws.com/artifact.tokbox.com/rel/ios-sdk/' + IosSDKVersion + '.tar.bz2',


### PR DESCRIPTION
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure you followed the Contribution Guidelines. Which can be found here:
https://github.com/opentok/cordova-plugin-opentok/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message

### Solves issue(s)
<!--- Mention the GitHub issues here -->
#180 
### Message

I just noticed that opentok installation was failing when running ```cordova build ios```. I got an error saying that ```Q``` was not a cordova module and could not be imported using ```requireCordovaModule``` and should be imported using the standard ```require``` method.

Let me know if I need to change a version number or something else. I really just replaced the ```requireCordovaModule``` call so it can be ```require```.