### PR TITLE
chore(plugin.xml): :sparkles: declare the opentok file in the js-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ cordova plugin remove com.tokbox.cordova.opentok
 
 All your editing will be done in your www folder.
 
-To use the opentok library, make sure you include `opentok.js` file in your HTML document.
+~~To use the opentok library, make sure you include `opentok.js` file in your HTML document.~~
+The `opentok.js` file is now automatically included by cordova.
 
 ```HTML
 <script type="text/javascript" charset="utf-8" src="opentok.js"></script>

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,6 +9,10 @@
     <license>Apache 2.0</license>
     <keywords>opentok,tokbox</keywords>
 
+    <js-module src="www/opentok.js" name="opentok">
+      <runs />
+    </js-module>
+
     <platform name="android">
       <framework src="build-extras.gradle" custom="true" type="gradleReference" />
       <framework src="com.android.support:appcompat-v7:23.1.0" />


### PR DESCRIPTION
It makes the opentok file show up in the cordova_plugin.js file.
It enables the `cordova-plugin-injectview` plugin to properly detect and inject the opentok files.
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure you followed the Contribution Guidelines. Which can be found here:
https://github.com/opentok/cordova-plugin-opentok/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message

### Solves issue(s)
<!--- Mention the GitHub issues here -->