### PR TITLE
chore(cocoapods): :sparkles: switch over to cocoapods for iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -9,6 +9,11 @@
     <license>Apache 2.0</license>
     <keywords>opentok,tokbox</keywords>
 
+    <engines>
+      <engine name="cordova" version=">=6.4.0" />
+      <engine name="cordova-ios" version=">=4.3.0" />
+    </engines>
+
     <platform name="android">
       <framework src="build-extras.gradle" custom="true" type="gradleReference" />
       <framework src="com.android.support:appcompat-v7:23.1.0" />
@@ -40,7 +45,6 @@
 
     <!-- ios -->
     <platform name="ios">
-      <hook type="before_plugin_install" src="scripts/downloadiOSSDK.js" />
       <asset src="www/opentok.js" target="opentok.js" />
 
       <header-file src="src/ios/UIView+Category.h" />
@@ -48,30 +52,14 @@
       <header-file src="src/ios/OpenTokPlugin.h" />
       <source-file src="src/ios/OpenTokPlugin.m" />
 
-      <framework src="libstdc++.dylib" />
-      <framework src="libc++.dylib" />
-      <framework src="libxml2.dylib" />
-      <framework src="libsqlite3.dylib" />
-      <framework src="libpthread.dylib" />
-      <framework src="VideoToolbox.framework" />
-      <framework src="src/ios/OpenTok.framework" custom="true" />
-      <framework src="AudioToolbox.framework" />
-      <framework src="CoreData.framework" />
-      <framework src="AVFoundation.framework" />
-      <framework src="CoreGraphics.framework" />
-      <framework src="CoreMedia.framework" />
-      <framework src="CoreVideo.framework" />
-      <framework src="OpenGLES.framework" />
-      <framework src="SystemConfiguration.framework" />
-      <framework src="CoreTelephony.framework" />
-      <framework src="GLKit.framework" />
-      <framework src="EventKit.framework" />
-      <framework src="QuartzCore.framework" />
-      <framework src="MapKit.framework" />
-      <framework src="UIKit.framework" />
-      <framework src="Foundation.framework" />
-      <framework src="Security.framework" />
-      <framework src="CFNetwork.framework" />
+      <podspec>
+        <config>
+          <source url="https://github.com/CocoaPods/Specs.git"/>
+        </config>
+        <pods>
+          <pod name="OpenTok" spec="2.15.3" />
+        </pods>
+      </podspec>
 
       <!-- Add support for background audio to the plist -->
       <!-- https://tokbox.com/developer/sdks/ios/background-state.html -->


### PR DESCRIPTION
Support for cocoapods has been added in [2016](https://github.com/apache/cordova-docs/commit/d12ebd74e73f309b2e25057ac734059a41152a47)

It needs `cordova-ios 4.3.0` and `cordova-cli 6.4.0`

<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure you followed the Contribution Guidelines. Which can be found here:
https://github.com/opentok/cordova-plugin-opentok/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message

### Solves issue(s)
<!--- Mention the GitHub issues here -->